### PR TITLE
Add support for debug info on syntax objects

### DIFF
--- a/explorer/example.rkt
+++ b/explorer/example.rkt
@@ -57,6 +57,10 @@
 			   (read-accept-lang #t))
 	      (read-syntax)))))
 
+  ;; try a macro-expanded piece of syntax
+  (send e add-item!
+        (expand #'(let () (define x 1) (+ x 1))))
+
   (send e add-item! here)
 
   (send e add-item! (explorer-item "testing exceptions"

--- a/explorer/main.rkt
+++ b/explorer/main.rkt
@@ -165,6 +165,10 @@
 					 (hash-items->explorer-items
 					  (map (lambda (k) (cons k (syntax-property stx k))) keys))
 					 stx))))
+              (let ((debug-info (syntax-debug-info stx)))
+                (list (explorer-item "- debug info"
+                                     (hash-items->explorer-items (hash->list debug-info))
+                                     stx)))
 	      (syntax-e stx)))
 
     (define/public (path->explorer-items p)

--- a/info.rkt
+++ b/info.rkt
@@ -1,4 +1,4 @@
 #lang setup/infotab
 (define collection 'multi)
-(define deps '("base"
+(define deps '(("base" #:version "6.2.900.4")
                "gui-lib"))


### PR DESCRIPTION
Displays debug information from `syntax-debug-info`. Includes binding information and scope sets from the lexical context.

Since this only works on HEAD, it may be worth setting up version exceptions. Or maybe it should try to degrade gracefully? I updated the dependencies to require a new version of Racket.